### PR TITLE
Cornelius is Rust-colored, not Flesh-colored

### DIFF
--- a/src/logic.rs
+++ b/src/logic.rs
@@ -12,7 +12,7 @@ pub fn get_info() -> JsonValue {
     return json!({
         "apiversion": "1",
         "author": "ChaelCodes",
-        "color": "#F09383",
+        "color": "#F6661E",
         "head": "bendr",
         "tail": "round-bum",
     });


### PR DESCRIPTION
Cornelius is intended to be an orange corn snake. They're supposed to be rust-colored, but the color ended up being a bit fleshier than intended.